### PR TITLE
Consistency ge module

### DIFF
--- a/src/consistency/consistency.f90
+++ b/src/consistency/consistency.f90
@@ -4,7 +4,5 @@ module yaeos__consistency
    !! central finite differences.
    ! Consistency test for ArModels
    use yaeos__consistency_armodel
-
-   ! TODO: Consistency test for GeModels
-   ! use yaeos__consistency_gemodel
+   use yaeos__consistency_gemodel
 end module yaeos__consistency

--- a/src/consistency/consistency_tests/consistency_armodel.f90
+++ b/src/consistency/consistency_tests/consistency_armodel.f90
@@ -19,7 +19,7 @@ module yaeos__consistency_armodel
    !!
    use yaeos__constants, only: pr, R
    use yaeos__models_ar, only: ArModel
-   use yaeos__thermoprops, only: enthalpy_residual_vt, gibbs_residual_vt 
+   use yaeos__thermoprops, only: enthalpy_residual_vt, gibbs_residual_vt
    use yaeos__thermoprops, only: fugacity_vt, pressure
 
    implicit none
@@ -29,9 +29,9 @@ contains
       )
       !! Evaluates the Michelsen and Mollerup (MM) consistency tests.
       !!
-      !! The evaluated equations are taken from Fundamentals & Computational 
-      !! Aspects 2 ed. by Michelsen and Mollerup Chapter 2 section 3. The 
-      !! "eq" are evaluations of the left hand side of the following 
+      !! The evaluated equations are taken from Fundamentals & Computational
+      !! Aspects 2 ed. by Michelsen and Mollerup Chapter 2 section 3. The
+      !! "eq" are evaluations of the left hand side of the following
       !! expressions:
       !!
       !! Equation 31:
@@ -49,8 +49,8 @@ contains
       !! Equation 34:
       !!
       !! \[
-      !!    \sum_i n_i 
-      !!    \left(\frac{\partial ln \hat{\phi}_i}{\partial n_j} \right)_{T,P} 
+      !!    \sum_i n_i
+      !!    \left(\frac{\partial ln \hat{\phi}_i}{\partial n_j} \right)_{T,P}
       !!    = 0
       !! \]
       !!
@@ -64,9 +64,37 @@ contains
       !! Equation 37:
       !!
       !! \[
-      !!    \sum_i n_i \left(\frac{\partial ln \hat{\phi}_i}{\partial T} 
+      !!    \sum_i n_i \left(\frac{\partial ln \hat{\phi}_i}{\partial T}
       !!    \right)_{P,n} + \frac{H^r(T,P,n)}{RT^2} = 0
       !! \]
+      !!
+      !! # Examples
+      !!
+      !! ```fortran
+      !!  use yaeos, only: pr, SoaveRedlichKwong, ArModel
+      !!  use yaeos__consistency, only: ar_consistency
+      !!
+      !!  class(ArModel), allocatable :: model
+      !!  real(pr) :: tc(4), pc(4), w(4)
+      !!
+      !!  real(pr) :: n(4), t, v
+      !!
+      !!  real(pr) :: eq31, eq33(size(n), size(n)), eq34(size(n)), eq36, eq37
+      !!
+      !!  n = [1.5, 0.2, 0.7, 2.3]
+      !!  tc = [190.564, 425.12, 300.11, 320.25]
+      !!  pc = [45.99, 37.96, 39.23, 40.21]
+      !!  w = [0.0115478, 0.200164, 0.3624, 0.298]
+      !!
+      !!  t = 600_pr
+      !!  v = 0.5_pr
+      !!
+      !!  model = SoaveRedlichKwong(tc, pc, w)
+      !!
+      !!  call ar_consistency(&
+      !!     model, n, v, t, eq31=eq31, eq33=eq33, eq34=eq34, eq36=eq36, eq37=eq37 &
+      !!     )
+      !! ```
       !!
       class(ArModel), intent(in) :: eos !! Model
       real(pr), intent(in) :: n(:) !! Moles number vector
@@ -159,6 +187,39 @@ contains
       Ar, ArV, ArT, Arn, ArV2, ArT2, ArTV, ArVn, ArTn, Arn2 &
       )
       !! Evaluate the Helmholtz derivatives with central finite difference.
+      !!
+      !! # Examples
+      !!
+      !! ```fortran
+      !!  use yaeos, only: pr, SoaveRedlichKwong, ArModel
+      !!  use yaeos__consistency, only: numeric_ar_derivatives
+      !!
+      !!  class(ArModel), allocatable :: model
+      !!  real(pr) :: tc(4), pc(4), w(4)
+      !!
+      !!  real(pr) :: n(4), t, v
+      !!
+      !!  real(pr) :: Ar_num, ArV_num, ArT_num, Arn_num(size(n)), ArV2_num, ArT2_num
+      !!  real(pr) :: ArTV_num, ArVn_num(size(n)), ArTn_num(size(n))
+      !!  real(pr) :: Arn2_num(size(n), size(n))
+      !!
+      !!  n = [1.5, 0.2, 0.7, 2.3]
+      !!  tc = [190.564, 425.12, 300.11, 320.25]
+      !!  pc = [45.99, 37.96, 39.23, 40.21]
+      !!  w = [0.0115478, 0.200164, 0.3624, 0.298]
+      !!
+      !!  t = 600_pr
+      !!  v = 0.5_pr
+      !!
+      !!  model = SoaveRedlichKwong(tc, pc, w)
+      !!
+      !!  call numeric_ar_derivatives(&
+      !!     model, n, v, t, d_n = 0.0001_pr, d_v = 0.0001_pr, d_t = 0.01_pr, &
+      !!     Ar=Ar_num, ArV=ArV_num, ArT=ArT_num, ArTV=ArTV_num, ArV2=ArV2_num, &
+      !!     ArT2=ArT2_num, Arn=Arn_num, ArVn=ArVn_num, ArTn=ArTn_num, &
+      !!     Arn2=Arn2_num &
+      !!     )
+      !! ```
       !!
       class(ArModel), intent(in) :: eos !! Model
       real(pr), intent(in) :: n(:) !! Moles number vector

--- a/src/consistency/consistency_tests/consistency_gemodel.f90
+++ b/src/consistency/consistency_tests/consistency_gemodel.f90
@@ -1,0 +1,340 @@
+module yaeos__consistency_gemodel
+   !! Consistency checks of excess Gibbs free energy models.
+   !!
+   !! This module contains tools to validate the analityc derivatives of
+   !! implmented excess Gibbs free energy models (GeModel). Also, allows to
+   !! evaluate the consistency tests described in Thermodynamic Models:
+   !! Fundamentals & Computational Aspects 2 ed. by Michelsen and Mollerup
+   !! Chapter 5 section 4.
+   !!
+   !! Available tools:
+   !!
+   !! - numeric_ge_derivatives: From an instantiated GeModel evaluate all the
+   !! excess Gibbs free energy derivatives from the central finite difference
+   !! method.
+   !!
+   !! - ge_consistency: From an instantiated GeModel evaluate all the Michelsen
+   !! and Mollerup consistency tests (refer to ge_consistency docs for more
+   !! explanations)
+   !!
+   use yaeos__constants, only: pr, R
+   use yaeos__models_ge, only: GeModel
+
+   implicit none
+contains
+   subroutine ge_consistency(model, n, t, eq58, eq59, eq60, eq61)
+      !! \(G^E\) models consistency tests
+      !!
+      !! # Description
+      !! Evaluate the \(G^E\) models consistency tests described in
+      !! Thermodynamic Models: Fundamentals & Computational Aspects 2 ed. by
+      !! Michelsen and Mollerup (MM) Chapter 5 section 4.
+      !!
+      !!  \[
+      !!   eq58 = \sum_i^{NC} n_i \text{ln} \gamma_i - \frac{G^E}{RT} = 0
+      !!  \]
+      !!
+      !!  \[
+      !!   eq59 = \text{ln} \gamma_i - \frac{1}{RT} 
+      !!   \frac{\partial G^E}{\partial n_i} = 0
+      !!  \]
+      !!
+      !!  \[
+      !!   eq60 = \frac{\partial \text{ln} \gamma_i}{\partial n_j} - 
+      !!   \frac{\partial \text{ln} \gamma_j}{\partial n_i} = 0
+      !!  \]
+      !!
+      !!  \[
+      !!   eq61 = \sum_i^{NC} n_i 
+      !!   \frac{\partial \text{ln} \gamma_i}{\partial n_j} = 0
+      !!  \]
+      !!
+      !! # Examples
+      !!
+      !! ```fortran
+      !!  use yaeos, only: pr
+      !!  use yaeos, only: Groups, setup_unifac, UNIFAC
+      !!  use yaeos__consistency_gemodel, only: ge_consistency
+      !!
+      !!  type(UNIFAC) :: model
+      !!
+      !!  integer, parameter :: nc = 4, ng = 4
+      !!
+      !!  type(Groups) :: molecules(nc)
+      !!
+      !!  real(pr) :: n(nc), T
+      !!  real(pr) :: dt, dn
+      !!
+      !!  real(pr) :: eq58, eq59(nc), eq60(nc,nc), eq61(nc)
+      !!
+      !!  T = 303.15
+      !!  n = [400.0, 100.0, 300.0, 200.0]
+      !!
+      !!  ! Hexane [CH3, CH2]
+      !!  molecules(1)%groups_ids = [1, 2]
+      !!  molecules(1)%number_of_groups = [2, 4]
+      !!
+      !!  ! Ethanol [CH3, CH2, OH]
+      !!  molecules(2)%groups_ids = [1, 2, 14]
+      !!  molecules(2)%number_of_groups = [1, 1, 1]
+      !!
+      !!  ! Toluene [ACH, ACCH3]
+      !!  molecules(3)%groups_ids = [9, 11]
+      !!  molecules(3)%number_of_groups = [5, 1]
+      !!
+      !!  ! Cyclohexane [CH2]
+      !!  molecules(4)%groups_ids = [2]
+      !!  molecules(4)%number_of_groups = [6]
+      !!
+      !!  model = setup_unifac(molecules)
+      !!
+      !!  ! ====================================================================
+      !!  ! Consistency tests
+      !!  ! --------------------------------------------------------------------
+      !!  call ge_consistency(model, n, t, eq58, eq59, eq60, eq61)
+      !! ```
+      !!
+      !! # References
+      !! Thermodynamic Models: Fundamentals & Computational Aspects 2 ed. Michelsen and Mollerup
+      !!
+      class(GeModel), intent(in) :: model
+      !! \(G^E\) model
+      real(pr), intent(in) :: n(:)
+      !! Moles number vector
+      real(pr), intent(in) :: t
+      !! Temperature [K]
+      real(pr), optional, intent(out) :: eq58
+      !! MM Eq. 58
+      real(pr), optional, intent(out) :: eq59(size(n))
+      !! MM Eq. 59
+      real(pr), optional, intent(out) :: eq60(size(n),size(n))
+      !! MM Eq. 60
+      real(pr), optional, intent(out) :: eq61(size(n))
+      !! MM Eq. 61
+
+      real(pr) :: Ge, Gen(size(n)), Gen2(size(n), size(n))
+      real(pr) :: ln_gammas(size(n))
+
+      integer i, j
+
+      call model%excess_gibbs(n, t, Ge=Ge, Gen=Gen, Gen2=Gen2)
+      call model%ln_activity_coefficient(n, t, ln_gammas)
+
+      ! ========================================================================
+      ! Equation 58
+      ! ------------------------------------------------------------------------
+      if (present(eq58)) then
+         eq58 = sum(n * ln_gammas) - Ge / R / T
+      end if
+
+      ! ========================================================================
+      ! Equation 59
+      ! ------------------------------------------------------------------------
+      if (present(eq59)) then
+         eq59 = Gen / R / T - ln_gammas
+      end if
+
+      ! ========================================================================
+      ! Equation 60
+      ! ------------------------------------------------------------------------
+      if (present(eq60)) then
+         eq60 = 0.0_pr
+         do i=1,size(n)
+            do j=1,size(n)
+               eq60(i,j) = Gen2(i,j) / R / T - Gen2(j,i) / R / T
+            end do
+         end do
+      end if
+
+      ! ========================================================================
+      ! Equation 61
+      ! ------------------------------------------------------------------------
+      if (present(eq61)) then
+         eq61 = 0.0_pr
+         do j=1,size(n)
+            eq61(j) = sum(n * Gen2(:, j) / R / T)
+         end do
+      end if
+   end subroutine ge_consistency
+
+   subroutine numeric_ge_derivatives(&
+      model, n, t, d_n, d_t, Ge, GeT, Gen, GeT2, GeTn, Gen2 &
+      )
+      !! # Numeric \(G^E\) model derivatives
+      !! Evaluate the excess Gibbs derivatives with central finite difference.
+      !!
+      !! # Examples
+      !!
+      !! ```fortran
+      !! use yaeos, only: Groups, setup_unifac, UNIFAC
+      !! use yaeos__consistency_gemodel, only: numeric_ge_derivatives
+      !!
+      !! type(UNIFAC) :: model
+      !!
+      !! integer, parameter :: nc = 4, ng = 4
+      !!
+      !! type(Groups) :: molecules(nc)
+      !!
+      !! real(pr) :: Ge, Gen(nc), GeT, GeT2, GeTn(nc), Gen2(nc, nc)
+      !! real(pr) :: Ge_n, Gen_n(nc), GeT_n, GeT2_n, GeTn_n(nc), Gen2_n(nc, nc)
+      !! real(pr) :: ln_gammas(nc)
+      !!
+      !! real(pr) :: n(nc), T
+      !! real(pr) :: dt, dn
+      !!
+      !! T = 303.15
+      !! n = [400.0, 100.0, 300.0, 200.0] ! always test with sum(n) > 1
+      !!
+      !! dt = 0.1_pr
+      !! dn = 0.1_pr
+      !!
+      !! ! Hexane [CH3, CH2]
+      !! molecules(1)%groups_ids = [1, 2]
+      !! molecules(1)%number_of_groups = [2, 4]
+      !!
+      !! ! Ethanol [CH3, CH2, OH]
+      !! molecules(2)%groups_ids = [1, 2, 14]
+      !! molecules(2)%number_of_groups = [1, 1, 1]
+      !!
+      !! ! Toluene [ACH, ACCH3]
+      !! molecules(3)%groups_ids = [9, 11]
+      !! molecules(3)%number_of_groups = [5, 1]
+      !!
+      !! ! Cyclohexane [CH2]
+      !! molecules(4)%groups_ids = [2]
+      !! molecules(4)%number_of_groups = [6]
+      !!
+      !! model = setup_unifac(molecules)
+      !!
+      !! ! =====================================================================
+      !! ! Call analytic derivatives
+      !! ! ---------------------------------------------------------------------
+      !! call model%excess_gibbs(n, T, Ge, GeT, GeT2, Gen, GeTn, Gen2)
+      !!
+      !! ! =====================================================================
+      !! ! Call numeric derivatives
+      !! ! ---------------------------------------------------------------------
+      !! call numeric_ge_derivatives(model, n, T, dn, dt, Ge=Ge_n, GeT=GeT_n)
+      !! call numeric_ge_derivatives(model, n, T, dn, dt, Ge=Ge_n, Gen=Gen_n)
+      !! call numeric_ge_derivatives(model, n, T, dn, dt, Ge=Ge_n, GeT2=GeT2_n)
+      !! call numeric_ge_derivatives(model, n, T, dn, dt, Ge=Ge_n, GeTn=GeTn_n)
+      !! call numeric_ge_derivatives(model, n, T, dn, dt, Ge=Ge_n, Gen2=Gen2_n)
+      !! ```
+      !!
+      class(GeModel), intent(in) :: model
+      !!Ge Model
+      real(pr), intent(in) :: n(:)
+      !! Moles number vector
+      real(pr), intent(in) :: t
+      !! Temperature [K]
+      real(pr), intent(in) :: d_n
+      !! Moles finite difference step
+      real(pr), intent(in) :: d_t
+      !! Temperature finite difference step
+      real(pr), intent(out) :: Ge
+      !! Residual Helmoltz energy
+      real(pr), optional, intent(out) :: GeT
+      !! \(\frac{dGe}{dT}\)
+      real(pr), optional, intent(out) :: Gen(size(n))
+      !! \(\frac{dGe}{dn_i}\)
+      real(pr), optional, intent(out) :: GeT2
+      !! \(\frac{d^2Ge}{dT^2}\)
+      real(pr), optional, intent(out) :: GeTn(size(n))
+      !! \(\frac{d^2Ge}{dTdn_i}\)
+      real(pr), optional, intent(out) :: Gen2(size(n), size(n))
+      !! \(\frac{d^2Ge}{dn_{ij}}\)
+
+      ! Auxiliary
+      real(pr) :: Ge_aux1, Ge_aux2, Ge_aux3, Ge_aux4
+      real(pr) :: dn_aux1(size(n)), dn_aux2(size(n))
+      integer :: i, j
+
+      ! ========================================================================
+      ! Ar valuations
+      ! ------------------------------------------------------------------------
+      ! on point valuation
+      call model%excess_gibbs(n, t, Ge=Ge)
+
+      ! ========================================================================
+      ! Central numeric derivatives
+      ! ------------------------------------------------------------------------
+      ! Temperature
+      if (present(GeT) .or. present(GeT2)) then
+         call model%excess_gibbs(n, t + d_t, Ge=Ge_aux1)
+         call model%excess_gibbs(n, t - d_t, Ge=Ge_aux2)
+
+         if (present(GeT)) GeT = (Ge_aux1 - Ge_aux2) / (2 * d_t)
+         if (present(GeT2)) GeT2 = (Ge_aux1 - 2 * Ge + Ge_aux2) / d_t**2
+      end if
+
+      ! Mole first derivatives
+      if (present(Gen)) then
+         Gen = 0.0_pr
+
+         do i = 1, size(n), 1
+            dn_aux1 = 0.0_pr
+            dn_aux1(i) = d_n
+
+            call model%excess_gibbs(n + dn_aux1, t, Ge=Ge_aux1)
+            call model%excess_gibbs(n - dn_aux1, t, Ge=Ge_aux2)
+
+            Gen(i) = (Ge_aux1 - Ge_aux2) / (2 * d_n)
+         end do
+      end if
+
+      ! ========================================================================
+      ! Central cross derivatives
+      ! ------------------------------------------------------------------------
+      ! Temperature - Mole
+      if (present(GeTn)) then
+         GeTn = 0.0_pr
+
+         do i = 1, size(n), 1
+            dn_aux1 = 0.0_pr
+            dn_aux1(i) = d_n
+
+            call model%excess_gibbs(n + dn_aux1, t + d_t, Ge=Ge_aux1)
+            call model%excess_gibbs(n + dn_aux1, t - d_t, Ge=Ge_aux2)
+            call model%excess_gibbs(n - dn_aux1, t + d_t, Ge=Ge_aux3)
+            call model%excess_gibbs(n - dn_aux1, t - d_t, Ge=Ge_aux4)
+
+            GeTn(i) = &
+               (Ge_aux1 - Ge_aux2 - Ge_aux3 + Ge_aux4) / (4 * d_t * d_n)
+         end do
+      end if
+
+      ! Mole second derivatives
+      if (present(Gen2)) then
+         Gen2 = 0.0_pr
+
+         do i = 1, size(n), 1
+            do j = 1, size(n), 1
+               if (i .eq. j) then
+                  dn_aux1 = 0.0_pr
+                  dn_aux1(i) = d_n
+
+                  call model%excess_gibbs(n + dn_aux1, t, Ge=Ge_aux1)
+                  call model%excess_gibbs(n - dn_aux1, t, Ge=Ge_aux2)
+
+                  Gen2(i, j) = (Ge_aux1 - 2 * Ge + Ge_aux2) / d_n**2
+               else
+                  dn_aux1 = 0.0_pr
+                  dn_aux2 = 0.0_pr
+
+                  dn_aux1(i) = d_n
+                  dn_aux2(j) = d_n
+
+                  call model%excess_gibbs(n + dn_aux1 + dn_aux2, t, Ge=Ge_aux1)
+                  call model%excess_gibbs(n + dn_aux1 - dn_aux2, t, Ge=Ge_aux2)
+                  call model%excess_gibbs(n - dn_aux1 + dn_aux2, t, Ge=Ge_aux3)
+                  call model%excess_gibbs(n - dn_aux1 - dn_aux2, t, Ge=Ge_aux4)
+
+                  Gen2(i, j) = &
+                     (Ge_aux1 - Ge_aux2 - Ge_aux3 + Ge_aux4) / (4 * d_n**2)
+               end if
+            end do
+         end do
+      end if
+   end subroutine numeric_ge_derivatives
+end module yaeos__consistency_gemodel
+

--- a/src/models/excess_gibbs/group_contribution/unifac.f90
+++ b/src/models/excess_gibbs/group_contribution/unifac.f90
@@ -211,7 +211,7 @@ contains
       !!
       !! ```fortran
       !!  ! Gibbs excess of ethane-ethanol-methyl amine mixture.
-      !!  use yaeos, only: R, pr, excess_gibbs, Groups, setup_unifac, UNIFAC
+      !!  use yaeos, only: R, pr, Groups, setup_unifac, UNIFAC
       !!
       !!  type(UNIFAC) :: model
       !!
@@ -242,7 +242,7 @@ contains
       !!  model = setup_unifac(molecules)
       !!
       !!  ! Call all Ge and derivatives
-      !!  call excess_gibbs(model, n, T, Ge, GeT, GeT2, Gen, GeTn, Gen2)
+      !!  call model%excess_gibbs(model, n, T, Ge, GeT, GeT2, Gen, GeTn, Gen2)
       !!
       !!  print *, "Ge: ", Ge
       !!  print *, "GeT: ", GeT
@@ -896,7 +896,7 @@ contains
       !!
       !! # References
       !!
-      class(UNIFACPsi) :: self 
+      class(UNIFACPsi) :: self
       !! \(\psi\) function
       class(Groups) :: systems_groups
       !! Groups in the system
@@ -904,7 +904,7 @@ contains
       !! Temperature [K]
       real(pr), optional, intent(out) :: psi(:, :)
       !! \(\psi\)
-      real(pr), optional, intent(out) :: dpsi_dt(:, :) 
+      real(pr), optional, intent(out) :: dpsi_dt(:, :)
       !! \(\frac{d \psi\}{dT} \)
       real(pr), optional, intent(out) :: dpsi_dt2(:, :)
       !! \(\frac{d^2 \psi\}{dT^2} \)
@@ -935,6 +935,17 @@ contains
    end subroutine UNIFAC_temperature_dependence
 
    function thetas_i(nm, ng, group_area, stew, molecules) result(thetas_ij)
+      !! # \(\Theta_i \) calculation
+      !! Calculate the area fraciton of each froup on each molecule.
+      !!
+      !! # Description
+      !! Calculate the area fraciton of each froup on each molecule. The values
+      !! are obtained on the setup_unifac function and stored on the UNIFAC
+      !! type, since the values can be reused (no compositional or temperature
+      !! dependence)
+      !!
+      !! # References
+      !!
       integer, intent(in) :: nm !! Number of molecules
       integer, intent(in) :: ng !! Number of groups
       real(pr), intent(in) :: group_area(:) !! Group k areas
@@ -945,7 +956,7 @@ contains
       real(pr) :: total_area_i(nm)
       real(pr) :: qki_contribution
 
-      integer :: gi !! group k id
+      integer :: gi
       integer :: i, j, k
 
       thetas_ij = 0.0_pr
@@ -1050,7 +1061,7 @@ contains
       type(Groups), intent(in) :: molecules(:)
       !! Molecules (Group type) objects
       real(pr), optional, intent(in) :: Aij(:, :)
-      !! Subgroup-subgroup interaction parameters matrix (if no provided loads 
+      !! Subgroup-subgroup interaction parameters matrix (if no provided loads
       !! default parameters)
       real(pr), optional, intent(in) :: Qk(:)
       !! Subgroups areas (if no provided loads default parameters)

--- a/test/test_implementations/ar_models/cubics/test_pr76.f90
+++ b/test/test_implementations/ar_models/cubics/test_pr76.f90
@@ -95,10 +95,12 @@ contains
          model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
          Ar=Ar_num, Arn2=Arn2_num)
 
-
-      call ar_consistency(&
-         model, n, v, t, eq31=eq31, eq33=eq33, eq34=eq34, eq36=eq36, eq37=eq37 &
-         )
+      ! Calling individually just because coverage
+      call ar_consistency(model, n, v, t, eq31=eq31)
+      call ar_consistency(model, n, v, t, eq33=eq33)
+      call ar_consistency(model, n, v, t, eq34=eq34)
+      call ar_consistency(model, n, v, t, eq36=eq36)
+      call ar_consistency(model, n, v, t, eq37=eq37)
 
       ! Numeric derivatives
       call check(error, rel_error(Ar, Ar_num) < 1e-6)

--- a/test/test_implementations/ar_models/cubics/test_pr76.f90
+++ b/test/test_implementations/ar_models/cubics/test_pr76.f90
@@ -58,12 +58,43 @@ contains
          n, v, t, Ar=Ar, ArV=ArV, ArT=ArT, Arn=Arn, &
          ArTV=ArTV, ArV2=ArV2, ArT2=ArT2, ArVn=ArVn, ArTn=ArTn, Arn2=Arn2)
 
+      ! Calling individually just because coverage
       call numeric_ar_derivatives(&
          model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
-         Ar=Ar_num, ArV=ArV_num, ArT=ArT_num, ArTV=ArTV_num, ArV2=ArV2_num, &
-         ArT2=ArT2_num, Arn=Arn_num, ArVn=ArVn_num, ArTn=ArTn_num, &
-         Arn2=Arn2_num &
-         )
+         Ar=Ar_num, ArV=ArV_num)
+
+      call numeric_ar_derivatives(&
+         model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
+         Ar=Ar_num, ArT=ArT_num)
+
+      call numeric_ar_derivatives(&
+         model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
+         Ar=Ar_num, ArTV=ArTV_num)
+
+      call numeric_ar_derivatives(&
+         model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
+         Ar=Ar_num, ArV2=ArV2_num)
+
+      call numeric_ar_derivatives(&
+         model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
+         Ar=Ar_num, ArT2=ArT2_num)
+
+      call numeric_ar_derivatives(&
+         model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
+         Ar=Ar_num, Arn=Arn_num)
+
+      call numeric_ar_derivatives(&
+         model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
+         Ar=Ar_num, ArVn=ArVn_num)
+
+      call numeric_ar_derivatives(&
+         model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
+         Ar=Ar_num, ArTn=ArTn_num)
+
+      call numeric_ar_derivatives(&
+         model, n, v, t, d_n = 0.0001_pr, d_v = 0.00001_pr, d_t = 0.001_pr, &
+         Ar=Ar_num, Arn2=Arn2_num)
+
 
       call ar_consistency(&
          model, n, v, t, eq31=eq31, eq33=eq33, eq34=eq34, eq36=eq36, eq37=eq37 &

--- a/test/test_implementations/ge_models/test_unifac.f90
+++ b/test/test_implementations/ge_models/test_unifac.f90
@@ -92,7 +92,10 @@ contains
       ! ========================================================================
       ! Consistency tests
       ! ------------------------------------------------------------------------
-      call ge_consistency(model, n, t, eq58, eq59, eq60, eq61)
+      call ge_consistency(model, n, t, eq58=eq58)
+      call ge_consistency(model, n, t, eq59=eq59)
+      call ge_consistency(model, n, t, eq60=eq60)
+      call ge_consistency(model, n, t, eq61=eq61)
 
       ! Eq 58
       call check(error, abs(eq58) < 1e-10_pr)

--- a/test/test_implementations/ge_models/test_unifac.f90
+++ b/test/test_implementations/ge_models/test_unifac.f90
@@ -10,14 +10,160 @@ contains
       type(unittest_type), allocatable, intent(out) :: testsuite(:)
 
       testsuite = [ &
+         new_unittest("Test UNIFAC consistency mixture", test_unifac_cons_mix), &
+         new_unittest("Test UNIFAC consistency pure", test_unifac_cons_pure), &
          new_unittest("Test UNIFAC against Caleb Bell's Thermo lib", test_against_caleb_thermo) &
          ]
    end subroutine collect_suite
 
+   subroutine test_unifac_cons_mix(error)
+      use yaeos, only: pr, R
+      use yaeos, only: Groups, setup_unifac, UNIFAC
+      use yaeos__consistency_gemodel, only: ge_consistency
+      use yaeos__consistency_gemodel, only: numeric_ge_derivatives
+
+      type(error_type), allocatable, intent(out) :: error
+
+      type(UNIFAC) :: model
+
+      integer, parameter :: nc = 4, ng = 4
+
+      type(Groups) :: molecules(nc)
+
+      real(pr) :: Ge, Gen(nc), GeT, GeT2, GeTn(nc), Gen2(nc, nc)
+      real(pr) :: Ge_n, Gen_n(nc), GeT_n, GeT2_n, GeTn_n(nc), Gen2_n(nc, nc)
+      real(pr) :: ln_gammas(nc)
+
+      real(pr) :: n(nc), T
+      real(pr) :: dt, dn
+
+      real(pr) :: eq58, eq59(size(n)), eq60(size(n),size(n)), eq61(size(n))
+
+      integer :: i, j
+
+      T = 303.15
+      n = [400.0, 100.0, 300.0, 200.0]
+
+      dt = 0.1_pr
+      dn = 0.1_pr
+
+      ! ! Hexane [CH3, CH2]
+      molecules(1)%groups_ids = [1, 2]
+      molecules(1)%number_of_groups = [2, 4]
+
+      ! ! Ethanol [CH3, CH2, OH]
+      molecules(2)%groups_ids = [1, 2, 14]
+      molecules(2)%number_of_groups = [1, 1, 1]
+
+      ! ! Toluene [ACH, ACCH3]
+      molecules(3)%groups_ids = [9, 11]
+      molecules(3)%number_of_groups = [5, 1]
+
+      ! ! Cyclohexane [CH2]
+      molecules(4)%groups_ids = [2]
+      molecules(4)%number_of_groups = [6]
+
+      model = setup_unifac(molecules)
+
+      ! ========================================================================
+      ! Call analytic derivatives
+      ! ------------------------------------------------------------------------
+      call model%excess_gibbs(n, T, Ge, GeT, GeT2, Gen, GeTn, Gen2)
+
+      ! ========================================================================
+      ! Call numeric derivatives
+      ! ------------------------------------------------------------------------
+      call numeric_ge_derivatives(model, n, T, dn, 0.01_pr, Ge=Ge_n, GeT=GeT_n)
+      call numeric_ge_derivatives(model, n, T, dn, dt, Ge=Ge_n, Gen=Gen_n)
+      call numeric_ge_derivatives(model, n, T, dn, dt, Ge=Ge_n, GeT2=GeT2_n)
+      call numeric_ge_derivatives(model, n, T, dn, dt, Ge=Ge_n, GeTn=GeTn_n)
+      call numeric_ge_derivatives(model, n, T, dn, dt, Ge=Ge_n, Gen2=Gen2_n)
+
+      ! Derivatives checks
+      call check(error, abs(Ge - Ge_n) < 1e-10)
+      call check(error, abs(GeT - GeT_n) < 1e-6)
+      call check(error, allclose(Gen, Gen_n, 1e-6_pr))
+      call check(error, abs(GeT2 - GeT2_n) < 1e-6)
+      call check(error, allclose(GeTn, GeTn_n, 1e-6_pr))
+      call check(error, allclose(Gen2(1,:), Gen2_n(1,:), 1e-5_pr))
+      call check(error, allclose(Gen2(2,:), Gen2_n(2,:), 1e-5_pr))
+      call check(error, allclose(Gen2(3,:), Gen2_n(3,:), 1e-5_pr))
+
+      ! ========================================================================
+      ! Consistency tests
+      ! ------------------------------------------------------------------------
+      call ge_consistency(model, n, t, eq58, eq59, eq60, eq61)
+
+      ! Eq 58
+      call check(error, abs(eq58) < 1e-10_pr)
+      
+      ! Eq 59
+      do i=1,size(n)
+         call check(error, abs(eq59(i)) < 1e-10_pr)
+      end do
+
+      ! Eq 60
+      do i=1,size(n)
+         do j=1,size(n)
+            call check(error, abs(eq60(i, j)) < 1e-10_pr)
+         end do
+      end do
+      
+      ! Eq 61
+      do i=1,size(n)
+         call check(error, abs(eq61(i)) < 1e-10_pr)
+      end do      
+   end subroutine test_unifac_cons_mix
+
+   subroutine test_unifac_cons_pure(error)
+      use yaeos, only: pr
+      use yaeos, only: Groups, UNIFAC, setup_unifac
+      
+      type(error_type), allocatable, intent(out) :: error
+
+      type(UNIFAC) :: model
+      type(Groups) :: molecules(1)
+
+      real(pr) :: Ge, Gen(1), GeT, GeT2, GeTn(1), Gen2(1, 1), ln_gammas(1)
+      real(pr) :: T, n(1)
+
+      integer :: i, j
+      
+      T = 303.15
+      n = [400.0]
+
+      ! Hexane [CH3, CH2]
+      molecules(1)%groups_ids = [1, 2]
+      molecules(1)%number_of_groups = [2, 4]
+
+      model  = setup_unifac(molecules)
+
+      ! Evaluate Ge and derivatives
+      call model%excess_gibbs(n, T, Ge, GeT, GeT2, Gen, GeTn, Gen2)
+      call model%ln_activity_coefficient(n, T, ln_gammas)
+
+      ! All must be zero for a pure compounds
+      call check(error, abs(Ge) < 1e-10_pr)
+      call check(error, abs(GeT) < 1e-10_pr)
+      call check(error, abs(GeT2) < 1e-10_pr)
+
+      do i=1,size(n)
+         call check(error, abs(Gen(i)) < 1e-10_pr)
+         call check(error, abs(GeTn(i)) < 1e-10_pr)
+         call check(error, abs(ln_gammas(i)) < 1e-10_pr)
+      end do
+
+      do i=1,size(n)
+         do j=1,size(n)
+            call check(error, abs(Gen2(i, j)) < 1e-10_pr)
+         end do
+      end do
+   end subroutine test_unifac_cons_pure
+
    subroutine test_against_caleb_thermo(error)
       ! https://github.com/CalebBell/thermo
       use yaeos, only: pr, R
-      use yaeos, only: excess_gibbs, Groups, setup_unifac, UNIFAC
+      use yaeos, only: Groups, setup_unifac, UNIFAC
 
       type(error_type), allocatable, intent(out) :: error
 
@@ -53,15 +199,15 @@ contains
       model = setup_unifac(molecules)
 
       ! Call all Ge and derivatives
-      call excess_gibbs(model, n, T, Ge, GeT, GeT2, Gen, GeTn, Gen2)
+      call model%excess_gibbs(n, T, Ge, GeT, GeT2, Gen, GeTn, Gen2)
 
       ! Call Ge and derivatives individually
-      call excess_gibbs(model, n, T, Ge_i)
-      call excess_gibbs(model, n, T, GeT=GeT_i)
-      call excess_gibbs(model, n, T, GeT2=GeT2_i)
-      call excess_gibbs(model, n, T, Gen=Gen_i)
-      call excess_gibbs(model, n, T, GeTn=GeTn_i)
-      call excess_gibbs(model, n, T, Gen2=Gen2_i)
+      call model%excess_gibbs(n, T, Ge_i)
+      call model%excess_gibbs(n, T, GeT=GeT_i)
+      call model%excess_gibbs(n, T, GeT2=GeT2_i)
+      call model%excess_gibbs(n, T, Gen=Gen_i)
+      call model%excess_gibbs(n, T, GeTn=GeTn_i)
+      call model%excess_gibbs(n, T, Gen2=Gen2_i)
 
       ! Call GeModel class method
       call model%ln_activity_coefficient(n, T, ln_gammas)
@@ -115,68 +261,68 @@ contains
       ! Test pair calls
       ! ------------------------------------------------------------------------
       ! Ge
-      call excess_gibbs(model, n, T, Ge=Ge_i, GeT=GeT_i)
+      call model%excess_gibbs(n, T, Ge=Ge_i, GeT=GeT_i)
       call check(error, abs(Ge - Ge_i) <= 1e-10)
       call check(error, abs(GeT - GeT_i) <= 1e-10)
 
-      call excess_gibbs(model, n, T, Ge=Ge_i, GeT2=GeT2_i)
+      call model%excess_gibbs(n, T, Ge=Ge_i, GeT2=GeT2_i)
       call check(error, abs(Ge - Ge_i) <= 1e-10)
       call check(error, abs(GeT2 - GeT2_i) <= 1e-10)
 
-      call excess_gibbs(model, n, T, Ge=Ge_i, Gen=Gen_i)
+      call model%excess_gibbs(n, T, Ge=Ge_i, Gen=Gen_i)
       call check(error, abs(Ge - Ge_i) <= 1e-10)
       call check(error, allclose(Gen, Gen_i, 1e-10_pr))
 
-      call excess_gibbs(model, n, T, Ge=Ge_i, GeTn=GeTn_i)
+      call model%excess_gibbs(n, T, Ge=Ge_i, GeTn=GeTn_i)
       call check(error, abs(Ge - Ge_i) <= 1e-10)
       call check(error, allclose(GeTn, GeTn_i, 1e-10_pr))
 
-      call excess_gibbs(model, n, T, Ge=Ge_i, Gen2=Gen2_i)
+      call model%excess_gibbs(n, T, Ge=Ge_i, Gen2=Gen2_i)
       call check(error, abs(Ge - Ge_i) <= 1e-10)
       call check(error, allclose(Gen2(1,:), Gen2_i(1,:), 1e-10_pr))
       call check(error, allclose(Gen2(2,:), Gen2_i(2,:), 1e-10_pr))
       call check(error, allclose(Gen2(3,:), Gen2_i(3,:), 1e-10_pr))
 
       ! Ge_T
-      call excess_gibbs(model, n, T, GeT=GeT_i, GeT2=GeT2_i)
+      call model%excess_gibbs(n, T, GeT=GeT_i, GeT2=GeT2_i)
       call check(error, abs(GeT - GeT_i) <= 1e-10)
       call check(error, abs(GeT2 - GeT2_i) <= 1e-10)
 
-      call excess_gibbs(model, n, T, GeT=GeT_i, Gen=Gen_i)
+      call model%excess_gibbs(n, T, GeT=GeT_i, Gen=Gen_i)
       call check(error, abs(GeT - GeT_i) <= 1e-10)
       call check(error, allclose(Gen, Gen_i, 1e-10_pr))
 
-      call excess_gibbs(model, n, T, GeT=GeT_i, GeTn=GeTn_i)
+      call model%excess_gibbs(n, T, GeT=GeT_i, GeTn=GeTn_i)
       call check(error, abs(GeT - GeT_i) <= 1e-10)
       call check(error, allclose(GeTn, GeTn_i, 1e-10_pr))
 
-      call excess_gibbs(model, n, T, GeT=GeT_i, Gen2=Gen2_i)
+      call model%excess_gibbs(n, T, GeT=GeT_i, Gen2=Gen2_i)
       call check(error, abs(GeT - GeT_i) <= 1e-10)
       call check(error, allclose(Gen2(1,:), Gen2_i(1,:), 1e-10_pr))
       call check(error, allclose(Gen2(2,:), Gen2_i(2,:), 1e-10_pr))
       call check(error, allclose(Gen2(3,:), Gen2_i(3,:), 1e-10_pr))
 
       ! Ge_T2
-      call excess_gibbs(model, n, T, GeT2=GeT2_i, Gen=Gen_i)
+      call model%excess_gibbs(n, T, GeT2=GeT2_i, Gen=Gen_i)
       call check(error, abs(GeT2 - GeT2_i) <= 1e-10)
       call check(error, allclose(Gen, Gen_i, 1e-10_pr))
 
-      call excess_gibbs(model, n, T, GeT2=GeT2_i, GeTn=GeTn_i)
+      call model%excess_gibbs(n, T, GeT2=GeT2_i, GeTn=GeTn_i)
       call check(error, abs(GeT2 - GeT2_i) <= 1e-10)
       call check(error, allclose(GeTn, GeTn_i, 1e-10_pr))
 
-      call excess_gibbs(model, n, T, GeT2=GeT2_i, Gen2=Gen2_i)
+      call model%excess_gibbs(n, T, GeT2=GeT2_i, Gen2=Gen2_i)
       call check(error, abs(GeT2 - GeT2_i) <= 1e-10)
       call check(error, allclose(Gen2(1,:), Gen2_i(1,:), 1e-10_pr))
       call check(error, allclose(Gen2(2,:), Gen2_i(2,:), 1e-10_pr))
       call check(error, allclose(Gen2(3,:), Gen2_i(3,:), 1e-10_pr))
 
       ! Gen_i
-      call excess_gibbs(model, n, T, Gen=Gen_i, GeTn=GeTn_i)
+      call model%excess_gibbs(n, T, Gen=Gen_i, GeTn=GeTn_i)
       call check(error, allclose(Gen, Gen_i, 1e-10_pr))
       call check(error, allclose(GeTn, GeTn_i, 1e-10_pr))
 
-      call excess_gibbs(model, n, T, Gen=Gen_i, Gen2=Gen2_i)
+      call model%excess_gibbs(n, T, Gen=Gen_i, Gen2=Gen2_i)
       call check(error, allclose(Gen, Gen_i, 1e-10_pr))
       call check(error, allclose(Gen2(1,:), Gen2_i(1,:), 1e-10_pr))
       call check(error, allclose(Gen2(2,:), Gen2_i(2,:), 1e-10_pr))
@@ -185,7 +331,7 @@ contains
       ! ========================================================================
       ! Just one triplet call test
       ! ------------------------------------------------------------------------
-      call excess_gibbs(model, n, T, Ge=Ge_i, GeT=GeT_i, Gen2=Gen2_i)
+      call model%excess_gibbs(n, T, Ge=Ge_i, GeT=GeT_i, Gen2=Gen2_i)
       call check(error, abs(Ge - Ge_i) <= 1e-10)
       call check(error, abs(GeT - GeT_i) <= 1e-10)
       call check(error, allclose(Gen2(1,:), Gen2_i(1,:), 1e-10_pr))


### PR DESCRIPTION
Consistency $G^E$ module done. Includes:
  - Consistency tests from Michelsen and Mollerup
  - Routine to calculate numeric derivatives of GeModel (as the ArModel consistency module)

The ge_consistency tests were successfully applied to UNIFAC.
 
Also the coverage of ar_consistency and ge_consistency are now 100%

Some documentation has been improved (I missed the UNIFAC theta_j doc)