### PR TITLE
Test path tool

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -33,6 +33,11 @@ finterp = { git = "https://github.com/jacobwilliams/finterp.git" }
 [dev-dependencies]
 test-drive = {git = "https://github.com/fortran-lang/test-drive"}
 
+
+# -----------------------------------------------------------------------------
+# Examples
+# -----------------------------------------------------------------------------
+
 # [[example]]
 # name       = "demo"
 # source-dir = "example/extra"
@@ -79,4 +84,9 @@ main       = "7_huron_vidal.f90"
 # main       = "cubic_eos.f90"
 # [example.dependencies]
 # nlopt-f = {git="https://github.com/grimme-lab/nlopt-f"}
+
+# -----------------------------------------------------------------------------
+# Tests
+# -----------------------------------------------------------------------------
+
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,5 +10,5 @@ are helpful for it's usage.
 
 ## Dev tools
 
-- [test_to_toml](./dev/test_to_toml): Tool to automatically add the Fortran
+- [test_to_toml](./dev/test_to_toml.py): Tool to automatically add the Fortran
   tests to the fpm.toml file.

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,4 +3,12 @@
 Here we provide a series of tools that are used externally of `yaeos`, but
 are helpful for it's usage.
 
+## User tools
+
 - [tapenade_diff](./tapenade_diff): Template and script to automatically differentiate a model using `tapenade` and include it into yaeos
+
+
+## Dev tools
+
+- [test_to_toml](./dev/test_to_toml): Tool to automatically add the Fortran
+  tests to the fpm.toml file.

--- a/tools/dev/test_to_toml.py
+++ b/tools/dev/test_to_toml.py
@@ -1,0 +1,63 @@
+"""Tool to automatically add the Fortran tests to the fpm.toml file.
+
+To use, simply run this scipt from any directory. It will add the tests to the
+fpm.toml file. The version control must be done manually.
+"""
+
+import toml
+from pathlib import Path
+
+
+root_path = Path(__file__).parent.parent.parent
+fpm_path = root_path / "fpm.toml"
+tests_path = root_path / "tests"
+
+
+# -- Read toml ----------------------------------------------------------------
+with open(fpm_path, "r") as f:
+    fpm = toml.load(f)
+
+
+# -- Get all tests in filesystem ----------------------------------------------
+found_tests = {}
+for f90 in sorted(tests_path.rglob("test_*.f90")):
+    name = f90.stem.removeprefix("test_")
+    found_tests[name] = {
+        "name": name,
+        "source-dir": f90.parent.relative_to(root_path).as_posix(),
+        "main": f90.name,
+    }
+
+
+# -- Get differences in toml and filesystem -----------------------------------
+existing_names = {t["name"] for t in fpm.get("test", [])}
+found_names = set(found_tests.keys())
+
+to_add = found_names - existing_names
+to_remove = existing_names - found_names
+
+
+# -- Apply changes ------------------------------------------------------------
+fpm.setdefault("test", [])
+
+fpm["test"] = [t for t in fpm["test"] if t["name"] not in to_remove]
+fpm["test"].extend(found_tests[name] for name in to_add)
+fpm["test"].sort(key=lambda t: t["name"])
+
+
+# -- Write changes ------------------------------------------------------------
+with open(fpm_path, "w") as f:
+    toml.dump(fpm, f)
+
+if to_add:
+    print(f"Added {len(to_add)} test(s):")
+    for name in sorted(to_add):
+        print(f"  + {name}  ({found_tests[name]['source-dir']}/{found_tests[name]['main']})")
+
+if to_remove:
+    print(f"Removed {len(to_remove)} test(s):")
+    for name in sorted(to_remove):
+        print(f"  - {name}")
+
+if not to_add and not to_remove:
+    print("fpm.toml is already up to date.")

--- a/tools/dev/test_to_toml.py
+++ b/tools/dev/test_to_toml.py
@@ -1,24 +1,26 @@
 """Tool to automatically add the Fortran tests to the fpm.toml file.
-
-To use, simply run this scipt from any directory. It will add the tests to the
+To use, simply run this script from any directory. It will add the tests to the
 fpm.toml file. The version control must be done manually.
 """
 
 import toml
+import re
 from pathlib import Path
-
 
 root_path = Path(__file__).parent.parent.parent
 fpm_path = root_path / "fpm.toml"
-tests_path = root_path / "tests"
+tests_path = root_path / "test"
 
 
-# -- Read toml ----------------------------------------------------------------
+
+# Read fpm.toml
 with open(fpm_path, "r") as f:
-    fpm = toml.load(f)
+    fpm_text = f.read()
+
+fpm = toml.loads(fpm_text)
 
 
-# -- Get all tests in filesystem ----------------------------------------------
+# Discover all tests in the filesystem
 found_tests = {}
 for f90 in sorted(tests_path.rglob("test_*.f90")):
     name = f90.stem.removeprefix("test_")
@@ -28,26 +30,63 @@ for f90 in sorted(tests_path.rglob("test_*.f90")):
         "main": f90.name,
     }
 
-
-# -- Get differences in toml and filesystem -----------------------------------
+# Calculate differences
 existing_names = {t["name"] for t in fpm.get("test", [])}
 found_names = set(found_tests.keys())
 
 to_add = found_names - existing_names
 to_remove = existing_names - found_names
 
-
-# -- Apply changes ------------------------------------------------------------
-fpm.setdefault("test", [])
-
-fpm["test"] = [t for t in fpm["test"] if t["name"] not in to_remove]
-fpm["test"].extend(found_tests[name] for name in to_add)
-fpm["test"].sort(key=lambda t: t["name"])
+if not to_add and not to_remove:
+    print("fpm.toml is already up to date.")
+    exit(0)
 
 
-# -- Write changes ------------------------------------------------------------
+# Remove [[test]] blocks that no longer exist
+for name in to_remove:
+    fpm_text = re.sub(
+        rf'\[\[test\]\][^\[]*?name\s*=\s*"{re.escape(name)}".*?(?=\[\[|\Z)',
+        "",
+        fpm_text,
+        flags=re.DOTALL,
+    )
+
+# Serialize the new blocks
+def test_block(t: dict) -> str:
+    return (
+        f'[[test]]\n'
+        f'name       = "{t["name"]}"\n'
+        f'source-dir = "{t["source-dir"]}"\n'
+        f'main       = "{t["main"]}"\n'
+    )
+
+# Merge existing and new tests, sorted alphabetically
+all_tests = {t["name"]: t for t in fpm.get("test", [])}
+all_tests.update({name: found_tests[name] for name in to_add})
+for name in to_remove:
+    all_tests.pop(name, None)
+
+new_test_section = "\n".join(test_block(t) for t in sorted(all_tests.values(), key=lambda t: t["name"]))
+
+
+# Replace or insert the [[test]] section in the text
+if re.search(r'\[\[test\]\]', fpm_text):
+    # Remove all existing [[test]] blocks and append the new section
+    fpm_text = re.sub(
+        r'(\[\[test\]\].*?)(?=\[\[(?!test)|\Z)',
+        "",
+        fpm_text,
+        flags=re.DOTALL,
+    )
+    fpm_text = fpm_text.rstrip() + "\n\n" + new_test_section
+else:
+    # No [[test]] blocks found: append at the end
+    fpm_text = fpm_text.rstrip() + "\n\n" + new_test_section + "\n"
+
+
+# Write
 with open(fpm_path, "w") as f:
-    toml.dump(fpm, f)
+    f.write(fpm_text)
 
 if to_add:
     print(f"Added {len(to_add)} test(s):")
@@ -58,6 +97,3 @@ if to_remove:
     print(f"Removed {len(to_remove)} test(s):")
     for name in sorted(to_remove):
         print(f"  - {name}")
-
-if not to_add and not to_remove:
-    print("fpm.toml is already up to date.")

--- a/tools/dev/test_to_toml.py
+++ b/tools/dev/test_to_toml.py
@@ -1,6 +1,9 @@
 """Tool to automatically add the Fortran tests to the fpm.toml file.
+
 To use, simply run this script from any directory. It will add the tests to the
 fpm.toml file. The version control must be done manually.
+
+python tools/dev/test_to_toml.py
 """
 
 import toml
@@ -10,7 +13,6 @@ from pathlib import Path
 root_path = Path(__file__).parent.parent.parent
 fpm_path = root_path / "fpm.toml"
 tests_path = root_path / "test"
-
 
 
 # Read fpm.toml
@@ -23,6 +25,12 @@ fpm = toml.loads(fpm_text)
 # Discover all tests in the filesystem
 found_tests = {}
 for f90 in sorted(tests_path.rglob("test_*.f90")):
+    content = f90.read_text()
+    if not (
+        re.search(r"^\s*program\b", content, re.IGNORECASE | re.MULTILINE)
+        and re.search(r"^\s*end\s+program\b", content, re.IGNORECASE | re.MULTILINE)
+    ):
+        continue
     name = f90.stem.removeprefix("test_")
     found_tests[name] = {
         "name": name,
@@ -31,13 +39,22 @@ for f90 in sorted(tests_path.rglob("test_*.f90")):
     }
 
 # Calculate differences
-existing_names = {t["name"] for t in fpm.get("test", [])}
+existing_tests = {t["name"]: t for t in fpm.get("test", [])}
 found_names = set(found_tests.keys())
+existing_names = set(existing_tests.keys())
 
 to_add = found_names - existing_names
 to_remove = existing_names - found_names
 
-if not to_add and not to_remove:
+# Tests with same name but different source-dir or main (moved/renamed file)
+to_update = {
+    name
+    for name in found_names & existing_names
+    if found_tests[name]["source-dir"] != existing_tests[name]["source-dir"]
+    or found_tests[name]["main"] != existing_tests[name]["main"]
+}
+
+if not to_add and not to_remove and not to_update:
     print("fpm.toml is already up to date.")
     exit(0)
 
@@ -51,29 +68,33 @@ for name in to_remove:
         flags=re.DOTALL,
     )
 
+
 # Serialize the new blocks
 def test_block(t: dict) -> str:
     return (
-        f'[[test]]\n'
+        f"[[test]]\n"
         f'name       = "{t["name"]}"\n'
         f'source-dir = "{t["source-dir"]}"\n'
         f'main       = "{t["main"]}"\n'
     )
 
+
 # Merge existing and new tests, sorted alphabetically
 all_tests = {t["name"]: t for t in fpm.get("test", [])}
-all_tests.update({name: found_tests[name] for name in to_add})
+all_tests.update({name: found_tests[name] for name in to_add | to_update})
 for name in to_remove:
     all_tests.pop(name, None)
 
-new_test_section = "\n".join(test_block(t) for t in sorted(all_tests.values(), key=lambda t: t["name"]))
+new_test_section = "\n".join(
+    test_block(t) for t in sorted(all_tests.values(), key=lambda t: t["name"])
+)
 
 
 # Replace or insert the [[test]] section in the text
-if re.search(r'\[\[test\]\]', fpm_text):
+if re.search(r"\[\[test\]\]", fpm_text):
     # Remove all existing [[test]] blocks and append the new section
     fpm_text = re.sub(
-        r'(\[\[test\]\].*?)(?=\[\[(?!test)|\Z)',
+        r"(\[\[test\]\].*?)(?=\[\[(?!test)|\Z)",
         "",
         fpm_text,
         flags=re.DOTALL,
@@ -91,9 +112,18 @@ with open(fpm_path, "w") as f:
 if to_add:
     print(f"Added {len(to_add)} test(s):")
     for name in sorted(to_add):
-        print(f"  + {name}  ({found_tests[name]['source-dir']}/{found_tests[name]['main']})")
+        print(
+            f"  + {name}  ({found_tests[name]['source-dir']}/{found_tests[name]['main']})"
+        )
 
 if to_remove:
     print(f"Removed {len(to_remove)} test(s):")
     for name in sorted(to_remove):
         print(f"  - {name}")
+
+if to_update:
+    print(f"Updated {len(to_update)} test(s):")
+    for name in sorted(to_update):
+        print(
+            f"  ~ {name}  ({found_tests[name]['source-dir']}/{found_tests[name]['main']})"
+        )

--- a/tools/dev/test_to_toml.py
+++ b/tools/dev/test_to_toml.py
@@ -1,8 +1,12 @@
-"""Tool to automatically add the Fortran tests to the fpm.toml file.
+"""Tool to automatically add discovered Fortran test programs to `fpm.toml`.
 
-To use, simply run this script from any directory. It will add the tests to the
-fpm.toml file. The version control must be done manually.
+To use, simply run this script from any directory. It updates the `[[test]]`
+entries in `fpm.toml`; the version control must be done manually.
 
+Only files under `test/` matching `test_*.f90` are considered. In addition,
+a file is only treated as a test if it contains both a Fortran `program`
+declaration and a matching `end program`, so helper modules and other sources
+in `test/` are intentionally ignored.
 python tools/dev/test_to_toml.py
 """
 


### PR DESCRIPTION
Probé:

- Crear un archivo .f90 que no siga el patrón test_*.f90 (no lo agrega al toml)
- Crear un archivo test_xxx.f90 vacío (no se agrega al toml)
- Crear un archivo test_xxx.f90 con cualquier cosa y que no tenga las instrucciones "program" y "end program" (no se agrega al toml)
- Agregarle las instrucciones de "program" a test_xxx.f90 (ahora si se agrega al toml)
- Quitarle una de las condiciones para ser incluido al archivo (al volver a correr el script se borra del toml)
- Mover de path a un archivo que ya estaba agregado al toml (al correr se da cuenta y lo actualiza y te avisa que actualiza)
- Borrar un archivo agregado al toml (lo saca del toml)

Correr el script con:

```
python tools/dev/test_to_toml.py
```