### PR TITLE
HVNRTL parameters from a kij

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,8 +14,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.12]
         toolchain:
-          - {compiler: gcc, version: 10}
-          - {compiler: gcc, version: 14}
+          - {compiler: gcc, version: 15}
           # - {compiler: intel, version: '2024.2'}
           # - {compiler: intel, version: '2023.2'}
     steps:
@@ -26,7 +25,7 @@ jobs:
 
     - name: Setup Fortran Compiler
       if: runner.os != 'Windows'
-      uses: fortran-lang/setup-fortran@v1.8.1
+      uses: fortran-lang/setup-fortran@v1.9.0
       id: setup-fortran
       with:
         compiler: ${{ matrix.toolchain.compiler }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,8 @@ jobs:
         os: [ubuntu-latest]
         python-version: [3.12]
         toolchain:
-          - {compiler: gcc, version: 15}
+          - {compiler: gcc, version: 10}
+          - {compiler: gcc, version: 14}
           # - {compiler: intel, version: '2024.2'}
           # - {compiler: intel, version: '2023.2'}
     steps:
@@ -25,7 +26,7 @@ jobs:
 
     - name: Setup Fortran Compiler
       if: runner.os != 'Windows'
-      uses: fortran-lang/setup-fortran@v1.9.0
+      uses: fortran-lang/setup-fortran@v1.8.1
       id: setup-fortran
       with:
         compiler: ${{ matrix.toolchain.compiler }}

--- a/c_interface/yaeos_c.f90
+++ b/c_interface/yaeos_c.f90
@@ -28,6 +28,7 @@ module yaeos_c
 
    ! CubicEoS
    public :: srk, pr76, pr78, rkpr, psrk, get_ac_b_del1_del2_k
+   public :: get_cubiceos_attractive_parameters, get_cubiceos_repulsive_parameters
    ! Mixing rules
    public :: set_mhv, set_qmr, set_qmrtd, set_hv, set_hvnrtl
    ! Multifluid equations
@@ -580,6 +581,7 @@ contains
       call extend_ar_models_list(id)
    end subroutine psrk
 
+   ! Get cubic parameters
    subroutine get_ac_b_del1_del2_k(id, ac, b, del1, del2, k, nc)
       use yaeos, only: CubicEoS, size, AlphaRKPR
       integer(c_int), intent(in) :: id
@@ -603,6 +605,56 @@ contains
          end select
       end associate
    end subroutine get_ac_b_del1_del2_k
+
+   subroutine get_cubiceos_attractive_parameters(id, nc, n, T, a, dadt, dadt2)
+      !! Get the attractive parameters of the cubic eos object for a range
+      !! of temperatures
+      use yaeos, only: pr, CubicEoS
+      integer(c_int), intent(in) :: id !! Model id
+      integer(c_int), intent(in) :: n !! Number of valuations
+      integer(c_int), intent(in) :: nc !! Number of components
+      real(c_double), intent(in) :: T(n) !! Temperatures to evaluate
+      real(c_double), intent(out) :: a(n, nc) !! Attractive parameter values
+      real(c_double), intent(out) :: dadt(n, nc) !! Attractive parameter values
+      real(c_double), intent(out) :: dadt2(n, nc) !! Attractive parameter values
+
+      integer :: i
+      real(pr) :: Tc(nc), ac(nc)
+      real(pr) :: Tr(nc)
+
+      ar_model = ar_models(id)%model
+
+      select type(ar_model)
+       class is (CubicEoS)
+         Tc = ar_model%components%Tc
+         ac = ar_model%ac
+         do i=1,n
+            Tr = T(i)/Tc
+            call ar_model%alpha%alpha(Tr, a(i, :), dadt(i, :), dadt2(i, :))
+            a(i, :) = ac * a(i, :)
+            dadt(i, :) = ac * dadt(i, :) / Tc
+            dadt2(i, :) = ac * dadt2(i, :) / Tc**2
+         end do
+      end select
+   end subroutine get_cubiceos_attractive_parameters
+
+   subroutine get_cubiceos_repulsive_parameters(id, nc, b)
+      !! Get the repulsive parameters of the cubic eos object
+      use yaeos, only: pr, CubicEoS
+      integer(c_int), intent(in) :: id !! Model id
+      integer(c_int), intent(in) :: nc !! Number of components
+      real(c_double), intent(out) :: b(nc) !! Repulsive parameter value
+
+      integer :: i
+      real(pr) :: Tr
+
+      ar_model = ar_models(id)%model
+
+      select type(ar_model)
+       class is (CubicEoS)
+         b = ar_model%b
+      end select
+   end subroutine get_cubiceos_repulsive_parameters
 
    ! ==========================================================================
    !  Multifluid equations
@@ -1618,7 +1670,7 @@ contains
          P0=P0, T0=T0, ns0=ns0, ds0=ds0, &
          beta_w=beta_w, points=max_points, max_pressure=stop_pressure, &
          allow_negative_betas=allow_negative_betas &
-      )
+         )
 
       do i=1,size(pt_mp%points)
          do j=1,np

--- a/python/yaeos/models/residual_helmholtz/cubic_eos/cubic_eos.py
+++ b/python/yaeos/models/residual_helmholtz/cubic_eos/cubic_eos.py
@@ -113,6 +113,42 @@ class CubicEoS(ArModel):
 
         return fcode
 
+    def get_attractive_parameter(self, temperatures: np.ndarray):
+        """Calculate the attractive parameter of the CubicEoS.
+
+        Parameters
+        ----------
+        temperatures : array_like
+            Range of temperatuers for which calculate the attractive parameter.
+
+        Returns 
+        -------
+        dict : Dictionary with the values of a for each component and its 
+               derivatives with temperature.
+        """
+        a, dadt, dadt2 = yaeos_c.get_cubiceos_attractive_parameters(
+            id=self.id, nc=self.size(), t=temperatures
+        )
+
+        return {
+            "a": a,
+            "dt": dadt,
+            "dt2": dadt2
+        }
+    
+    def get_repulsive_parameter(self):
+        """Calculate the repulsive parameters of the CubicEoS.
+
+        Returns 
+        -------
+            array : Repulsive parameter value for each component.
+        """
+        b = yaeos_c.get_cubiceos_repulsive_parameters(
+            id=self.id, nc=self.size()
+        )
+
+        return b
+
 
 class PengRobinson76(CubicEoS):
     """Peng-Robinson 1976 cubic equation of state.

--- a/python/yaeos/models/residual_helmholtz/cubic_eos/mixing_rules.py
+++ b/python/yaeos/models/residual_helmholtz/cubic_eos/mixing_rules.py
@@ -627,3 +627,91 @@ class HVNRTL(CubicMixRule):
             "logical :: use_kij(nc,nc)\n\n"
         )
         return fcode
+
+    @classmethod
+    def setup_from_kij(cls, model, temperatures, kij):
+        r"""
+        Generalizes the calculation of gji parameters and returns linear 
+        correlation matrices gji0 and gjiT for any number of components.
+
+        .. warning::
+           Internally this function depends on the :math:`\delta_1` of the
+           model. For the case of the RKPR EoS where there are different
+           :math:`\delta_1` parameters for each component the method will
+           only use a mean value. Which will make the predictions further
+           away of the predictions being made with :math:`k_{ij}` compared
+           to using classic Cubic EoS. This method is intended only as a way
+           to ease the initialization of parameters on optimization methods. 
+
+        Parameters
+        ----------
+        model: yaeos.CubicEoS
+            Thermodynamic model intended to be used as reference model.
+        temperatures: array_like
+            Array of temperature values on which make the correlation
+        kij: float
+            kij value to replicate.
+
+        Returns
+        -------
+            yaeos.HVNRTL: Instance of a HVNRTL mixing rule with parameters
+            set to be close the parameters that would replicate the classic
+            QMR mixing rule.
+        """
+        from yaeos.lib import yaeos_c
+        def lambd(d1=1+np.sqrt(2)):
+            f = d1 + 1
+            g = (d1 + 1)*d1 + d1 - 1
+            h = np.log((d1+1)**2 / 2)
+            L = f/g * h
+            return L
+        
+        # 1. Setup basic parameters
+        nc = model.size()
+        ac, b, del1, del2, k = yaeos_c.get_ac_b_del1_del2_k(model.id, nc)
+        nt = len(temperatures)
+        ais = model.get_attractive_parameter(temperatures)["a"]  # Shape: (nt, nc)
+        bis = model.get_repulsive_parameter()          # Shape: (nc,)
+        lambd = lambd(np.mean(del1))
+        
+        # Storage for all gji matrices across all temperatures
+        # Shape: (Temperature, Component_j, Component_i)
+        gjiss = np.zeros((nt, nc, nc))
+        
+        # 2. Calculate gji at each Temperature
+        for t_idx, T in enumerate(temperatures):
+            ais_i = ais[t_idx]
+            
+            # Calculate gii (pure component interaction) for this T
+            # gii = - (a_i / b_i) * lambda
+            gii = - (ais_i / bis) * lambd
+            
+            gji_temp = np.zeros((nc, nc))
+            for i in range(nc):
+                for j in range(nc):
+                    # Cross-interaction term logic
+                    term1 = -2 * np.sqrt(bis[i] * bis[j]) / (bis[i] + bis[j])
+                    term2 = np.sqrt(gii[i] * gii[j]) * (1 - kij)
+                    
+                    # gji = (Interaction Term) - gii[i]
+                    gji_temp[j, i] = (term1 * term2) - gii[i]
+            
+            gjiss[t_idx] = gji_temp
+
+        # 3. Linear Correlation: gji = gji0 + gjiT * T
+        gji0 = np.zeros((nc, nc))
+        gjiT = np.zeros((nc, nc))
+        
+        for i in range(nc):
+            for j in range(nc):
+                if i != j:
+                    # Extract the vector of values for parameter g[j,i] over time
+                    y = gjiss[:, j, i]
+                    
+                    # Polyfit returns [slope, intercept]
+                    slope, intercept = np.polyfit(temperatures, y, deg=1)
+                    
+                    gjiT[j, i] = slope
+                    gji0[j, i] = intercept
+
+        return cls(alpha=np.zeros((nc,nc)), gji=gji0, gjiT=gjiT)


### PR DESCRIPTION
The HVNRTL mixing rule can represent the classic QMR mixing rule when using the following definitions:

1. Pure Component Interaction Parameter
 
$g_{ii}(T) = -\frac{a_i(T)}{b_i} \cdot \Lambda$

2. Cross-Interaction Parameter

$g_{ji}(T) = \left( \frac{-2\sqrt{b_i b_j}}{b_i + b_j} \cdot \sqrt{g_{ii}(T) g_{jj}(T)} \cdot (1 - k_{ij}) \right) - g_{ii}(T)$

3. Linear Temperature Correlation

$g_{ji}(T) \approx g_{ji,0} + g_{ji,T} \cdot T$

4. Dimensionless Interaction Parameter (Tau)
$\tau_{ji} = \frac{g_{ji}(T)}{RT} = \frac{g_{ji,0} + g_{ji,T} \cdot T}{RT}; \alpha_{ji}=0$

The new method in the HVNRTL mixing rule does the opposite. From a $k_{ij}$ value it looks for the parameters $g_{ji,0}$ and $g_{ji,T}$ that will give the closest predictions than with the $k_{ij}$ value 