### PR TITLE
Fix gerg excess

### DIFF
--- a/python/tests/models/residual_helmholtz/test_ar_same_as_fortran.py
+++ b/python/tests/models/residual_helmholtz/test_ar_same_as_fortran.py
@@ -125,12 +125,11 @@ for i, mixrule in enumerate(mixrules):
         model_names.append(f"{cla.name} with {mixrule.name} mixrule")
 
 # =============================================================================
-# TODO Fix bug on GERG2008 (Excess properties not working)
 # Multifluid EoS
 # -----------------------------------------------------------------------------
-# model = yaeos.GERG2008(["n-hexane", "decane", "isobutane"])
-# models_list.append(model)
-# model_names.append("GERG2008")
+model = yaeos.GERG2008(["n-hexane", "decane", "isobutane"])
+models_list.append(model)
+model_names.append("GERG2008")
 
 # =============================================================================
 # SAFT EoS

--- a/python/yaeos/core.py
+++ b/python/yaeos/core.py
@@ -3542,7 +3542,7 @@ class ArModel(ABC):
         kind_w=None,
         max_points=MAX_POINTS_ENVELOPES,
         stop_pressure=2500,
-        allow_negative_betas=False
+        allow_negative_betas=False,
     ) -> PTEnvelope:
         """Multi-phase envelope."""
         x_l0 = np.array(x_l0)
@@ -3570,7 +3570,7 @@ class ArModel(ABC):
                 kind_w=kind_w,
                 max_points=max_points,
                 stop_pressure=stop_pressure,
-                allow_negative_betas=allow_negative_betas
+                allow_negative_betas=allow_negative_betas,
             )
         )
 
@@ -3825,12 +3825,8 @@ class ArModel(ABC):
             return dsps, locs_1, locs_2
 
         for t, p in zip(temperatures, pressures):
-            env1_loc = (
-                np.argmin(np.abs(env1["T"] - t) + np.abs(env1["P"] - p))
-            )
-            env2_loc = (
-                np.argmin(np.abs(env2["T"] - t) + np.abs(env2["P"] - p))
-            )
+            env1_loc = np.argmin(np.abs(env1["T"] - t) + np.abs(env1["P"] - p))
+            env2_loc = np.argmin(np.abs(env2["T"] - t) + np.abs(env2["P"] - p))
 
             betas_1 = env1.main_phases_molar_fractions[env1_loc, :]
             betas_2 = env2.main_phases_molar_fractions[env2_loc, :]

--- a/python/yaeos/fitting/core.py
+++ b/python/yaeos/fitting/core.py
@@ -234,9 +234,13 @@ class BinaryFitter:
                 if x1 == y1:
                     # No separation at TP
                     if not np.isnan(x[0]):
-                        sat = model.saturation_pressure(x, kind="bubble", temperature=t)
+                        sat = model.saturation_pressure(
+                            x, kind="bubble", temperature=t
+                        )
                     else:
-                        sat = model.saturation_pressure(y, kind="dew", temperature=t)
+                        sat = model.saturation_pressure(
+                            y, kind="dew", temperature=t
+                        )
                     error_i = self.pressure_error(p, sat["P"])
 
                 elif np.isnan(x[0]):

--- a/src/models/residual_helmholtz/multifluid/gerg2008.f90
+++ b/src/models/residual_helmholtz/multifluid/gerg2008.f90
@@ -321,7 +321,7 @@ contains
       v0 = self%srk%get_v0(n, p, t)
    end function volume_initalizer
 
-    subroutine ln_activity_coefficient(&
+   subroutine ln_activity_coefficient(&
       eos, n, P, T, root_type, lngamma, dlngammadP, dlngammadT, dlngammadn &
       )
       !! Calculate natural logarithm of activity coefficients and its

--- a/src/models/residual_helmholtz/multifluid/gerg2008.f90
+++ b/src/models/residual_helmholtz/multifluid/gerg2008.f90
@@ -349,11 +349,11 @@ contains
       real(pr), intent(out), optional :: lngamma(size(n))
       !! Natural logarithm of activity coefficient
       real(pr), intent(out), optional :: dlngammadP(size(n))
-      !! \(\frac{d\ln\gamma}}{dP}\)
+      !! \(\frac{d\ln\gamma}{dP}\)
       real(pr), intent(out), optional :: dlngammadT(size(n))
-      !! \(\frac{d\ln\gamma}}{dT}\)
+      !! \(\frac{d\ln\gamma}{dT}\)
       real(pr), intent(out), optional :: dlngammadn(size(n),size(n))
-      !! \(\frac{d\ln\gamma}}{dn}\)
+      !! \(\frac{d\ln\gamma}{dn}\)
 
       ! Mixture properties
       real(pr) :: lnPhi(size(n)), dlnPhidT(size(n))

--- a/src/models/residual_helmholtz/multifluid/gerg2008.f90
+++ b/src/models/residual_helmholtz/multifluid/gerg2008.f90
@@ -12,11 +12,13 @@ module yaeos__models_ar_gerg2008
    type, extends(ArModelAdiff) :: Gerg2008
       type(Gerg2008Pure), allocatable :: pures(:)
       type(Gerg2008Binary), allocatable :: binaries(:, :)
+      integer, allocatable :: ids(:)
       type(CubicEoS) :: srk
    contains
       procedure :: ar => arfun
       procedure :: get_v0 => volume_initalizer
       procedure :: volume => volume
+      procedure :: ln_activity_coefficient => ln_activity_coefficient
    end type Gerg2008
 
    type, private :: GERG2008Selector
@@ -56,6 +58,7 @@ contains
       call get_original_parameters(ids, pures, binaries, gerg_2008%components)
       gerg_2008%pures = pures
       gerg_2008%binaries = binaries
+      gerg_2008%ids = ids
       gerg_2008%srk =SoaveRedlichKwong(gerg_2008%components%Tc, gerg_2008%components%Pc, gerg_2008%components%w)
    end function gerg_2008
 
@@ -317,4 +320,112 @@ contains
       real(pr) :: v0
       v0 = self%srk%get_v0(n, p, t)
    end function volume_initalizer
+
+    subroutine ln_activity_coefficient(&
+      eos, n, P, T, root_type, lngamma, dlngammadP, dlngammadT, dlngammadn &
+      )
+      !! Calculate natural logarithm of activity coefficients and its
+      !! derivatives given pressure and temperature.
+      !!
+      !! # Examples
+      !!
+      !! ```fortran ! eos = PengRobinson76(Tc, Pc, w)
+      !!
+      !! n = [1.0_pr, 1.0_pr] ! T = 300.0_pr ! P = 1.0_pr
+      !!
+      !! call eos%ln_activity_coefficient(&
+      !!    n, P, T, root_type="stable", &
+      !!    lngamma=lngamma, dlngammadP=dlngammadP, &
+      !!    dlngammadT=dlngammadT, dlngammadn=dlngammadn &
+      !!    )
+      !! ```
+      class(GERG2008), intent(in) :: eos !! Model
+      real(pr), intent(in) :: n(:) !! Moles number vector
+      real(pr), intent(in) :: P !! Pressure [bar]
+      real(pr), intent(in) :: T !! Temperature [K]
+      character(len=*), intent(in) :: root_type
+      !! Desired root-type to solve. Options are:
+      !! `["liquid", "vapor", "stable"]`
+      real(pr), intent(out), optional :: lngamma(size(n))
+      !! Natural logarithm of activity coefficient
+      real(pr), intent(out), optional :: dlngammadP(size(n))
+      !! \(\frac{d\ln\gamma}}{dP}\)
+      real(pr), intent(out), optional :: dlngammadT(size(n))
+      !! \(\frac{d\ln\gamma}}{dT}\)
+      real(pr), intent(out), optional :: dlngammadn(size(n),size(n))
+      !! \(\frac{d\ln\gamma}}{dn}\)
+
+      ! Mixture properties
+      real(pr) :: lnPhi(size(n)), dlnPhidT(size(n))
+      real(pr) :: dlnPhidn(size(n),size(n))
+      real(pr) :: dPdV, dPdn(size(n)), dVdn(size(n))
+
+      ! Pure properties
+      real(pr) :: vi(size(n)), vi_temp, npure(size(n))
+      real(pr) :: lnPhi_i(size(n)), dlnPhi_i_dT(size(n))
+      real(pr) :: lnPhi_i_temp(1), dlnPhi_i_dT_temp(1)
+      type(GERG2008) :: eos_temp
+
+      integer :: i
+
+      logical :: gam, dp, dt, dn, present_derivs
+
+      gam = present(lngamma)
+      dp = present(dlngammadP)
+      dt = present(dlngammadT)
+      dn = present(dlngammadn)
+      present_derivs = dp .or. dt .or. dn
+
+
+      ! Call to mixture fugacity coefficient at PT
+      ! TODO: maybe more efficient later?
+      if (.not. present_derivs) then
+         call eos%lnphi_pt(n=n, P=P, T=T, root_type=root_type, lnPhi=lnPhi)
+      else
+         call eos%lnphi_pt(&
+            n=n, P=P, T=T, root_type=root_type, &
+            lnPhi=lnPhi, dlnPhidT=dlnPhidT, dlnPhidn=dlnPhidn, &
+            dPdV=dPdV, dPdn=dPdn &
+            )
+
+         dVdn = -dPdn / dPdV
+      end if
+
+      ! Pure components calls
+      vi = 0.0_pr
+      lnPhi_i = 0.0_pr
+
+      if (dt) then
+         dlnPhi_i_dT = 0.0_pr
+      end if
+
+      do i=1, size(n)
+         eos_temp = gerg_2008([eos%ids(i)])
+
+         if (.not. dt) then
+            call eos_temp%lnphi_pt(&
+               n=[1.0_pr], P=P, T=T, V=vi_temp, root_type="stable", &
+               lnPhi=lnPhi_i_temp &
+               )
+         else
+            call eos_temp%lnphi_pt(&
+               n=[1.0_pr], P=P, T=T, V=vi_temp, root_type="stable", &
+               lnPhi=lnPhi_i_temp, dlnPhidT=dlnPhi_i_dT_temp &
+               )
+         end if
+
+         vi(i) = vi_temp
+         lnPhi_i(i) = lnPhi_i_temp(1)
+
+         if (dt) then
+            dlnPhi_i_dT(i) = dlnPhi_i_dT_temp(1)
+         end if
+      end do
+
+      ! returns
+      if (gam) lngamma = lnPhi - lnPhi_i
+      if (dt) dlngammadT = dlnPhidT - dlnPhi_i_dT
+      if (dp) dlngammadP = (dVdn - vi) / (Ryaeos * T)
+      if (dn) dlngammadn = dlnPhidn
+   end subroutine ln_activity_coefficient
 end module yaeos__models_ar_gerg2008

--- a/test/test_gerg2008.f90
+++ b/test/test_gerg2008.f90
@@ -4,18 +4,26 @@ program main
    use yaeos__consistency_armodel, only: numeric_ar_derivatives
    use testing_aux, only: test_title, assert
    implicit none
-   type(Gerg2008) :: model
+   type(Gerg2008) :: model, methane, nitrogen, co2
    type(CubicEoS) :: cubic
 
+   ! Numeric tests
    real(pr) :: n(2), v, t, n0(2)
    real(pr) :: ar, arv, arv2
    real(pr) :: art, art2, artv
    real(pr) :: arvn(2), artn(2), arn(2), arn2(2,2)
    real(pr) :: f1, f2, f3, f4, dx
    integer :: comps(2) = [1, 4]
-
    real(pr) :: Arnum, ArVnum, ArV2Num, ArTnum, ArT2num, ArTVnum, ArNnum(2), ArN2num(2,2)
 
+   ! ln_gamma tests
+   real(pr) :: ln_gamma(3), dlngammadP(3), dlngammadT(3), dlngammadn(3,3)
+   real(pr) :: ln_phis_pures(3), ln_phis(3), vi(3), ln_phi_temp(1), vi_temp
+   real(pr) :: ln_gamma_from_phis(3)
+
+   ! ===========================================================================
+   ! Numeric tests
+   ! ---------------------------------------------------------------------------
    model = gerg_2008(comps)
    cubic = model%srk
 
@@ -27,8 +35,8 @@ program main
    T = 150
 
    call model%residual_helmholtz(&
-         n, v, t, ar=ar, arv=arv, art=art, artv=artv, &
-         arv2=arv2, art2=art2, arn=arn, arvn=arvn, artn=artn, arn2=arn2)
+      n, v, t, ar=ar, arv=arv, art=art, artv=artv, &
+      arv2=arv2, art2=art2, arn=arn, arvn=arvn, artn=artn, arn2=arn2)
    call assert(abs(ar - (-11.1819)) < 1e-4, "Ar Value from literature")
 
    call numeric_ar_derivatives(&
@@ -49,14 +57,68 @@ program main
    call model%volume(n, 1.0_pr, T, f1, root_type="liquid")
    call cubic%volume(n, 1.0_pr, T, f2, root_type="liquid")
    call assert(abs(f1 - f2) < 1e-2, "Liquid root close to SRK")
-   
+
    call model%volume(n, 1.0_pr, T, f1, root_type="vapor")
    call cubic%volume(n, 1.0_pr, T, f2, root_type="vapor")
 
    call assert(abs(f1 - f2) < 0.1, "Vapor root close to SRK")
-   
+
    call model%volume(n, 1.0_pr, T, f1, root_type="stable")
    call cubic%volume(n, 1.0_pr, T, f2, root_type="stable")
    call assert(abs(f1 - f2) < 1e-1, "Stable root close to SRK")
+
+   ! ===========================================================================
+   ! Tests of ln_gamma
+   ! ---------------------------------------------------------------------------
+   model = gerg_2008([1, 2, 3])
+   methane = gerg_2008([1])
+   nitrogen = gerg_2008([2])
+   co2 = gerg_2008([3])
+
+   call model%ln_activity_coefficient(&
+      [2.0_pr, 2.0_pr, 3.0_pr], &
+      1.0_pr, &
+      303.15_pr, &
+      root_type="stable", &
+      lngamma=ln_gamma, &
+      dlngammadP=dlngammadP, &
+      dlngammadT=dlngammadT, &
+      dlngammadn=dlngammadn &
+      )
+
+   call model%lnphi_pt(&
+      [2.0_pr, 2.0_pr, 3.0_pr], &
+      1.0_pr, &
+      303.15_pr, &
+      root_type="stable", &
+      lnphi=ln_phis &
+      )
+
+   call methane%lnphi_pt(&
+      [1.0_pr], 1.0_pr, 303.15_pr, V=vi_temp, root_type="stable", lnphi=ln_phi_temp &
+      )
+   vi(1) = vi_temp
+   ln_phis_pures(1) = ln_phi_temp(1)
+
+   call nitrogen%lnphi_pt(&
+      [1.0_pr], 1.0_pr, 303.15_pr, V=vi_temp, root_type="stable", lnphi=ln_phi_temp &
+      )
+   vi(2) = vi_temp
+   ln_phis_pures(2) = ln_phi_temp(1)
+
+   call co2%lnphi_pt(&
+      [1.0_pr], 1.0_pr, 303.15_pr, V=vi_temp, root_type="stable", lnphi=ln_phi_temp &
+      )
+   vi(3) = vi_temp
+   ln_phis_pures(3) = ln_phi_temp(1)
+
+   ! Test gamma
+   ln_gamma_from_phis = ln_phis - ln_phis_pures
+
+   call assert( &
+      all(abs(ln_gamma - ln_gamma_from_phis) < 1e-10_pr), &
+      "ln_gamma matches lnphi mixture - lnphi pure" &
+      )
+
 
 end program main

--- a/test/test_gerg2008.f90
+++ b/test/test_gerg2008.f90
@@ -18,7 +18,10 @@ program main
 
    ! ln_gamma tests
    real(pr) :: ln_gamma(3), dlngammadP(3), dlngammadT(3), dlngammadn(3,3)
-   real(pr) :: ln_phis_pures(3), ln_phis(3), vi(3), ln_phi_temp(1), vi_temp
+   real(pr) :: ln_phis_pures(3), ln_phis(3), dln_phis_dT(3), vi(3)
+   real(pr) :: ln_phi_temp(1), vi_temp, dln_phis_pures_dT(3), dln_phi_dT_temp(1)
+   real(pr) :: dln_phis_pures_dP(3), dln_phi_dP_temp(1), dln_phis_dP(3)
+   real(pr) :: dln_phis_dn(3,3)
    real(pr) :: ln_gamma_from_phis(3)
 
    ! ===========================================================================
@@ -91,26 +94,42 @@ program main
       1.0_pr, &
       303.15_pr, &
       root_type="stable", &
-      lnphi=ln_phis &
+      lnphi=ln_phis, &
+      dlnPhidT=dln_phis_dT, &
+      dlnPhidP=dln_phis_dP, &
+      dlnPhidn=dln_phis_dn &
       )
 
+   ! Pure calls
    call methane%lnphi_pt(&
-      [1.0_pr], 1.0_pr, 303.15_pr, V=vi_temp, root_type="stable", lnphi=ln_phi_temp &
+      [1.0_pr], 1.0_pr, 303.15_pr, V=vi_temp, &
+      root_type="stable", lnphi=ln_phi_temp, dlnPhidT=dln_phi_dT_temp, &
+      dlnPhidP=dln_phi_dP_temp &
       )
    vi(1) = vi_temp
    ln_phis_pures(1) = ln_phi_temp(1)
+   dln_phis_pures_dT(1) = dln_phi_dT_temp(1)
+   dln_phis_pures_dP(1) = dln_phi_dP_temp(1)
 
    call nitrogen%lnphi_pt(&
-      [1.0_pr], 1.0_pr, 303.15_pr, V=vi_temp, root_type="stable", lnphi=ln_phi_temp &
+      [1.0_pr], 1.0_pr, 303.15_pr, V=vi_temp, &
+      root_type="stable", lnphi=ln_phi_temp, dlnPhidT=dln_phi_dT_temp, &
+      dlnPhidP=dln_phi_dP_temp &
       )
    vi(2) = vi_temp
    ln_phis_pures(2) = ln_phi_temp(1)
+   dln_phis_pures_dT(2) = dln_phi_dT_temp(1)
+   dln_phis_pures_dP(2) = dln_phi_dP_temp(1)
 
    call co2%lnphi_pt(&
-      [1.0_pr], 1.0_pr, 303.15_pr, V=vi_temp, root_type="stable", lnphi=ln_phi_temp &
+      [1.0_pr], 1.0_pr, 303.15_pr, V=vi_temp, &
+      root_type="stable", lnphi=ln_phi_temp, dlnPhidT=dln_phi_dT_temp, &
+      dlnPhidP=dln_phi_dP_temp &
       )
    vi(3) = vi_temp
    ln_phis_pures(3) = ln_phi_temp(1)
+   dln_phis_pures_dT(3) = dln_phi_dT_temp(1)
+   dln_phis_pures_dP(3) = dln_phi_dP_temp(1)
 
    ! Test gamma
    ln_gamma_from_phis = ln_phis - ln_phis_pures
@@ -120,5 +139,21 @@ program main
       "ln_gamma matches lnphi mixture - lnphi pure" &
       )
 
+   ! Gamma temperature derivative
+   call assert( &
+      all(abs(dlngammadT - (dln_phis_dT - dln_phis_pures_dT)) < 1e-10_pr), &
+      "dlngammadT matches lnphi mixture - lnphi pure" &
+      )
 
+   ! Gamma pressure derivative
+   call assert( &
+      all(abs(dlngammadP - (dln_phis_dP - dln_phis_pures_dP)) < 1e-10_pr), &
+      "dlngammadP matches lnphi mixture - lnphi pure" &
+      )
+
+   ! Gamma mole derivative
+   call assert( &
+      all(abs(dlngammadn - dln_phis_dn) < 1e-10_pr), &
+      "dlngammadn matches lnphi mixture - lnphi pure" &
+      )
 end program main

--- a/test/test_gerg2008.f90
+++ b/test/test_gerg2008.f90
@@ -154,6 +154,6 @@ program main
    ! Gamma mole derivative
    call assert( &
       all(abs(dlngammadn - dln_phis_dn) < 1e-10_pr), &
-      "dlngammadn matches lnphi mixture - lnphi pure" &
+      "dlngammadn matches dlnphi/dn of the mixture" &
       )
 end program main


### PR DESCRIPTION
Pisé el método `ln_activity_coefficients` de la GERG2008 para que pueda calcular todas las propiedades de exceso. Tuve que guardar los `ids` que ingresaron en el constructor como atributo. Para valuar los gammas instancio una GERG pura a partir de cada `id` cuando se llama al método de los gammas. Me daba un poco de asco que quedaran instanciados, por eso lo hice así.

Agregue un test para testear el método particular de la GERG y habilité a la GERG en los same_as_fortran del lado Python porque la habia dejado comentada.

El problema surge de que la GERG no te deja evaluar cosas en composiciones [1.0, 0.0, 0.0].